### PR TITLE
Fix the hide options

### DIFF
--- a/src/knockout.reactor.js
+++ b/src/knockout.reactor.js
@@ -112,7 +112,7 @@ ko['watch'] = function (target, options, evaluatorCallback, context) {
 
                 // Ignore hidden objects. Also applies to any of their children.
                 if (options.hide)
-                    if (ko.utils.arrayIndexOf(options.hide, child) > -1)
+                    if (ko.utils.arrayIndexOf(options.hide, fieldName) > -1)
                         return;
 
                 // Merge parents. Using a fresh array so it is not referenced in the next recursion if any.


### PR DESCRIPTION
I think there was a typo at the line 115.  
The "ko.utils.arrayIndexOf(options.hide, child)" was comparing the array of string with the object 'child' which always resulted in a false statement