### PR TITLE
Add Universal Module Definition to be able to use it with RequireJS

### DIFF
--- a/src/knockout.reactor.js
+++ b/src/knockout.reactor.js
@@ -13,7 +13,7 @@
     } else {
         factory(window.ko);
     }
-}(function (ko, $) {
+}(function (ko) {
 ko.subscribable.fn['watch'] = function (targetOrCallback, options, evaluatorCallback, context) {
     /// <summary>
     ///     Track and manage changes within the chained observable down to any given level. 

--- a/src/knockout.reactor.js
+++ b/src/knockout.reactor.js
@@ -2,7 +2,18 @@
 // (c) Ziad Jeeroburkhan
 // License: MIT (http://www.opensource.org/licenses/mit-license.php)
 // Version 1.3.6
-
+; (function (factory) {
+    // CommonJS
+    if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
+        factory(require('knockout'));
+        // AMD
+    } else if (typeof define === 'function' && define.amd) {
+        define(['knockout'], factory);
+        // Normal script tag
+    } else {
+        factory(window.ko);
+    }
+}(function (ko, $) {
 ko.subscribable.fn['watch'] = function (targetOrCallback, options, evaluatorCallback, context) {
     /// <summary>
     ///     Track and manage changes within the chained observable down to any given level. 
@@ -290,3 +301,5 @@ ko['watch'] = function (target, options, evaluatorCallback, context) {
         }
     };
 };
+
+}));


### PR DESCRIPTION
Hello, I think it will be nice to to add Universal Module Definition. So knockout-reactor can be used with RequireJS and other module loaders.
More here:  https://github.com/umdjs/umd

Thanks
